### PR TITLE
Add CombDetector, a naive polyphonic pitch detector

### DIFF
--- a/src/detector/internals.rs
+++ b/src/detector/internals.rs
@@ -1,4 +1,5 @@
 use num_complex::Complex;
+use num_traits::Zero;
 use rustfft::FFTplanner;
 
 use crate::float::Float;
@@ -12,6 +13,7 @@ use crate::utils::peak::correct_peak;
 use crate::utils::peak::detect_peaks;
 use crate::utils::peak::PeakCorrection;
 
+#[derive(Clone)]
 pub struct Pitch<T>
 where
     T: Float,
@@ -44,12 +46,12 @@ where
         let mut complex_buffers: Vec<Vec<Complex<T>>> = Vec::new();
 
         for _i in 0..n_real_buffers {
-            let v = new_real_buffer(size + padding);
+            let v = new_real_buffer(size + padding, T::zero());
             real_buffers.push(v);
         }
 
         for _i in 0..n_complex_buffers {
-            let v = new_complex_buffer(size + padding);
+            let v = new_complex_buffer(size + padding, Complex::zero());
             complex_buffers.push(v);
         }
 

--- a/src/detector/mod.rs
+++ b/src/detector/mod.rs
@@ -4,6 +4,7 @@ use crate::float::Float;
 pub mod autocorrelation;
 pub mod internals;
 pub mod mcleod;
+pub mod polyphonic;
 
 pub trait PitchDetector<T>
 where
@@ -16,4 +17,17 @@ where
         power_threshold: T,
         clarity_threshold: T,
     ) -> Option<Pitch<T>>;
+}
+
+pub trait PolyphonicDetector<T>
+where
+    T: Float,
+{
+    fn get_pitch(
+        &mut self,
+        signal: &[T],
+        sample_rate: usize,
+        power_threshold: T,
+        clarity_threshold: T,
+    ) -> Vec<Option<Pitch<T>>>;
 }

--- a/src/detector/polyphonic/comb.rs
+++ b/src/detector/polyphonic/comb.rs
@@ -1,0 +1,107 @@
+use num_complex::Complex;
+use num_traits::Zero;
+use rustfft::FFTplanner;
+
+use crate::detector::internals::Pitch;
+use crate::detector::PitchDetector;
+use crate::detector::PolyphonicDetector;
+use crate::float::Float;
+use crate::utils::buffer::copy_complex_to_real;
+use crate::utils::buffer::copy_real_to_complex;
+use crate::utils::buffer::new_complex_buffer;
+use crate::utils::buffer::new_real_buffer;
+use crate::utils::buffer::ComplexComponent;
+use crate::utils::filters::comb_filter;
+
+pub struct CombDetector<T>
+where
+    T: Float,
+{
+    detector: Box<dyn PitchDetector<T>>,
+    limit: usize,
+}
+
+impl<T> CombDetector<T>
+where
+    T: Float,
+{
+    pub fn new(detector: Box<dyn PitchDetector<T>>, limit: usize) -> Self {
+        CombDetector { detector, limit }
+    }
+}
+
+impl<T> PolyphonicDetector<T> for CombDetector<T>
+where
+    T: Float,
+{
+    fn get_pitch(
+        &mut self,
+        signal: &[T],
+        sample_rate: usize,
+        power_threshold: T,
+        clarity_threshold: T,
+    ) -> Vec<Option<Pitch<T>>> {
+        let mut pitches = vec![None; self.limit];
+        let size = signal.len();
+        let size_t = T::from_usize(size).unwrap();
+
+        let mut signal_complex: Vec<Complex<T>> = new_complex_buffer(size, Complex::zero());
+        let mut scratch: Vec<Complex<T>> = new_complex_buffer(size, Complex::zero());
+        let mut comb_g: Vec<T> = new_real_buffer(signal.len(), T::one());
+        let mut remaining_signal: Vec<T> = signal.to_vec();
+
+        let beta = T::from_f64(50.).unwrap(); // TODO: expose this as a paremeter
+
+        let mut planner = FFTplanner::new(false);
+        let fft = planner.plan_fft(size);
+        let mut planner = FFTplanner::new(true);
+        let inv_fft = planner.plan_fft(size);
+
+        for iter in 0..self.limit {
+            let pitch = self.detector.get_pitch(
+                &remaining_signal,
+                sample_rate,
+                power_threshold,
+                clarity_threshold,
+            );
+
+            let stop = match pitch {
+                Some(p) => {
+                    pitches[iter] = Some(p.clone());
+
+                    copy_real_to_complex(
+                        &remaining_signal,
+                        &mut signal_complex,
+                        ComplexComponent::Re,
+                    );
+                    fft.process(&mut signal_complex, &mut scratch);
+                    comb_filter(p.frequency, beta, size, sample_rate, &mut comb_g);
+
+                    scratch
+                        .iter_mut()
+                        .zip(comb_g.iter())
+                        .for_each(|(s_value, c_value)| {
+                            s_value.re = s_value.re * (*c_value) / size_t;
+                            s_value.im = s_value.im * (*c_value) / size_t;
+                        });
+
+                    inv_fft.process(&mut scratch, &mut signal_complex);
+                    copy_complex_to_real(
+                        &signal_complex,
+                        &mut remaining_signal,
+                        ComplexComponent::Re,
+                    );
+
+                    false
+                }
+                None => true,
+            };
+
+            if stop {
+                return pitches;
+            }
+        }
+
+        pitches
+    }
+}

--- a/src/detector/polyphonic/mod.rs
+++ b/src/detector/polyphonic/mod.rs
@@ -1,0 +1,4 @@
+use crate::detector::internals::Pitch;
+use crate::float::Float;
+
+pub mod comb;

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -1,7 +1,23 @@
 use num_traits::float::FloatCore as NumFloatCore;
 use rustfft::FFTnum;
 
-pub trait Float: NumFloatCore + FFTnum {}
+pub trait Number {
+    fn exp(&self) -> Self;
+}
+
+impl Number for f64 {
+    fn exp(&self) -> Self {
+        f64::exp(*self)
+    }
+}
+
+impl Number for f32 {
+    fn exp(&self) -> Self {
+        f32::exp(*self)
+    }
+}
+
+pub trait Float: NumFloatCore + FFTnum + Number {}
 
 impl Float for f64 {}
 impl Float for f32 {}

--- a/src/utils/buffer.rs
+++ b/src/utils/buffer.rs
@@ -8,12 +8,12 @@ pub enum ComplexComponent {
     Im,
 }
 
-pub fn new_real_buffer<T: Float>(size: usize) -> Vec<T> {
-    vec![T::zero(); size]
+pub fn new_real_buffer<T: Float>(size: usize, fill: T) -> Vec<T> {
+    vec![fill; size]
 }
 
-pub fn new_complex_buffer<T: Float>(size: usize) -> Vec<Complex<T>> {
-    vec![Complex::zero(); size]
+pub fn new_complex_buffer<T: Float>(size: usize, fill: Complex<T>) -> Vec<Complex<T>> {
+    vec![fill; size]
 }
 
 pub fn copy_real_to_complex<T: Float>(

--- a/src/utils/filters.rs
+++ b/src/utils/filters.rs
@@ -1,0 +1,44 @@
+use crate::float::Float;
+
+pub fn comb_filter<T>(freq: T, beta: T, size: usize, sample_rate: usize, result: &mut [T])
+where
+    T: Float,
+{
+    assert_eq!(size, result.len());
+
+    let dh = T::from_usize(size).unwrap() / T::from_usize(sample_rate).unwrap();
+
+    let max_freq = T::from_usize(size / 2).unwrap() / dh;
+    let one = T::one();
+    let two = one + one;
+
+    let mut nodes = vec![];
+
+    let mut f = freq;
+    while f < max_freq {
+        nodes.push(f);
+        f = f * two;
+    }
+
+    for val in result.iter_mut() {
+        *val = one;
+    }
+
+    for idx in 0..(size / 2) {
+        let i = idx + 1;
+        let f = T::from_usize(i).unwrap() / dh;
+
+        for node in nodes.iter() {
+            let mut arg = (f - *node).abs() / beta;
+            arg = arg * arg;
+            let damp = one - (-arg).exp();
+            result[i] = result[i] * damp;
+        }
+    }
+
+    for idx in 0..(size / 2) {
+        let i = idx + 1;
+        let j = size - idx - 1;
+        result[j] = result[i];
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod buffer;
+pub mod filters;
 pub mod peak;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,45 +1,44 @@
 use pitch_detection::detector::autocorrelation::AutocorrelationDetector;
 use pitch_detection::detector::mcleod::McLeodDetector;
+use pitch_detection::detector::polyphonic::comb::CombDetector;
 use pitch_detection::detector::PitchDetector;
+use pitch_detection::detector::PolyphonicDetector;
 use pitch_detection::float::Float;
 use pitch_detection::utils::buffer::new_real_buffer;
 
 #[test]
 fn autocorrelation_sin_signal() {
-    pure_frequency(String::from("Autocorrelation"), String::from("sin"), 440.0);
+    mono_frequency("Autocorrelation", "sin", 440.0);
 }
 
 #[test]
 fn mcleod_sin_signal() {
-    pure_frequency(String::from("McLeod"), String::from("sin"), 440.0);
+    mono_frequency("McLeod", "sin", 440.0);
 }
 
 #[test]
 fn autocorrelation_square_signal() {
-    pure_frequency(
-        String::from("Autocorrelation"),
-        String::from("square"),
-        440.0,
-    );
+    mono_frequency("Autocorrelation", "square", 440.0);
 }
 
 #[test]
 fn mcleod_square_signal() {
-    pure_frequency(String::from("McLeod"), String::from("square"), 440.0);
+    mono_frequency("McLeod", "square", 440.0);
 }
 
 #[test]
 fn autocorrelation_triange_signal() {
-    pure_frequency(
-        String::from("Autocorrelation"),
-        String::from("triangle"),
-        440.0,
-    );
+    mono_frequency("Autocorrelation", "triangle", 440.0);
 }
 
 #[test]
 fn mcleod_triangle_signal() {
-    pure_frequency(String::from("McLeod"), String::from("triangle"), 440.0);
+    mono_frequency("McLeod", "triangle", 440.0);
+}
+
+#[test]
+fn mcleod_poly_square_signal() {
+    poly_frequency("McLeod", "square", &[440.0, 523.25, 659.25]);
 }
 
 fn get_chunk<T: Float>(signal: &[T], start: usize, window: usize, output: &mut [T]) {
@@ -63,7 +62,7 @@ fn get_chunk<T: Float>(signal: &[T], start: usize, window: usize, output: &mut [
 }
 
 fn sin_wave<T: Float>(freq: f64, size: usize, sample_rate: usize) -> Vec<T> {
-    let mut signal = new_real_buffer(size);
+    let mut signal = new_real_buffer(size, T::zero());
     let two_pi = 2.0 * std::f64::consts::PI;
     let dx = two_pi * freq / sample_rate as f64;
     for i in 0..size {
@@ -75,7 +74,7 @@ fn sin_wave<T: Float>(freq: f64, size: usize, sample_rate: usize) -> Vec<T> {
 }
 
 fn square_wave<T: Float>(freq: f64, size: usize, sample_rate: usize) -> Vec<T> {
-    let mut signal = new_real_buffer(size);
+    let mut signal = new_real_buffer(size, T::zero());
     let period = sample_rate as f64 / freq;
 
     for i in 0..size {
@@ -91,7 +90,7 @@ fn square_wave<T: Float>(freq: f64, size: usize, sample_rate: usize) -> Vec<T> {
 }
 
 fn triangle_wave<T: Float>(freq: f64, size: usize, sample_rate: usize) -> Vec<T> {
-    let mut signal = new_real_buffer(size);
+    let mut signal = new_real_buffer(size, T::zero());
     let period = sample_rate as f64 / freq;
 
     for i in 0..size {
@@ -109,7 +108,7 @@ fn triangle_wave<T: Float>(freq: f64, size: usize, sample_rate: usize) -> Vec<T>
 }
 
 fn saw_wave<T: Float>(freq: f64, size: usize, sample_rate: usize) -> Vec<T> {
-    let mut signal = new_real_buffer(size);
+    let mut signal = new_real_buffer(size, T::zero());
     let period = sample_rate as f64 / freq;
 
     for i in 0..size {
@@ -126,7 +125,7 @@ fn saw_wave<T: Float>(freq: f64, size: usize, sample_rate: usize) -> Vec<T> {
     signal
 }
 
-fn detector_factory(name: String, window: usize, padding: usize) -> Box<dyn PitchDetector<f64>> {
+fn detector_factory(name: &str, window: usize, padding: usize) -> Box<dyn PitchDetector<f64>> {
     match name.as_ref() {
         "McLeod" => {
             return Box::new(McLeodDetector::<f64>::new(window, padding));
@@ -140,7 +139,7 @@ fn detector_factory(name: String, window: usize, padding: usize) -> Box<dyn Pitc
     }
 }
 
-fn signal_factory<T: Float>(name: String, freq: f64, size: usize, sample_rate: usize) -> Vec<T> {
+fn signal_factory<T: Float>(name: &str, freq: f64, size: usize, sample_rate: usize) -> Vec<T> {
     match name.as_ref() {
         "sin" => {
             return sin_wave(freq, size, sample_rate);
@@ -160,7 +159,7 @@ fn signal_factory<T: Float>(name: String, freq: f64, size: usize, sample_rate: u
     }
 }
 
-fn pure_frequency(detector_name: String, wave_name: String, freq_in: f64) {
+fn mono_frequency(detector_name: &str, wave_name: &str, freq_in: f64) {
     const SAMPLE_RATE: usize = 48000;
     const DURATION: f64 = 4.0;
     const SAMPLE_SIZE: usize = (SAMPLE_RATE as f64 * DURATION) as usize;
@@ -173,7 +172,7 @@ fn pure_frequency(detector_name: String, wave_name: String, freq_in: f64) {
 
     let signal = signal_factory::<f64>(wave_name, freq_in, SAMPLE_SIZE, SAMPLE_RATE);
 
-    let mut chunk = new_real_buffer(WINDOW);
+    let mut chunk = new_real_buffer(WINDOW, 0.0_f64);
 
     let mut detector = detector_factory(detector_name, WINDOW, PADDING);
 
@@ -201,4 +200,112 @@ fn pure_frequency(detector_name: String, wave_name: String, freq_in: f64) {
             }
         }
     }
+}
+
+fn poly_frequency(detector_name: &str, wave_name: &str, freqs_in: &[f64]) {
+    const SAMPLE_RATE: usize = 48000;
+    const DURATION: f64 = 4.0;
+    const SAMPLE_SIZE: usize = (SAMPLE_RATE as f64 * DURATION) as usize;
+    const WINDOW: usize = 1024 * 4;
+    const PADDING: usize = WINDOW / 2;
+    const DELTA_T: usize = WINDOW / 4;
+    const N_WINDOWS: usize = (SAMPLE_SIZE - WINDOW) / DELTA_T;
+    const POWER_THRESHOLD: f64 = 300.0;
+    const CLARITY_THRESHOLD: f64 = 0.6;
+
+    let mut signal = new_real_buffer(SAMPLE_SIZE, 0.0_f64);
+
+    for freq in freqs_in.iter() {
+        let freq_signal = signal_factory::<f64>(wave_name, *freq, SAMPLE_SIZE, SAMPLE_RATE);
+        for (s0, s1) in freq_signal.iter().zip(signal.iter_mut()) {
+            *s1 = *s1 + *s0;
+        }
+    }
+
+    let mut chunk = new_real_buffer(WINDOW, 0.0_f64);
+
+    let monophonic_detector = detector_factory(detector_name, WINDOW, PADDING);
+    let mut detector = Box::new(CombDetector::<f64>::new(
+        monophonic_detector,
+        freqs_in.len(),
+    ));
+
+    let n_tests = N_WINDOWS * freqs_in.len();
+    let mut failures = 0;
+
+    for i in 0..N_WINDOWS {
+        let t: usize = i * DELTA_T;
+        get_chunk(&signal, t, WINDOW, &mut chunk);
+
+        let pitches = detector.get_pitch(&chunk, SAMPLE_RATE, POWER_THRESHOLD, CLARITY_THRESHOLD);
+
+        let mut remaining_freqs_in = vec![0.0; freqs_in.len()];
+        remaining_freqs_in.copy_from_slice(freqs_in);
+
+        for (pitch_i, pitch) in pitches.iter().enumerate() {
+            match pitch {
+                Some(pitch) => {
+                    let frequency = pitch.frequency;
+                    let clarity = pitch.clarity;
+                    let idx = SAMPLE_RATE as f64 / frequency;
+                    let epsilon = (SAMPLE_RATE as f64 / (idx - 1.0)) - frequency;
+                    println!(
+                        "Poly #{} - Chosen Peak idx: {}; clarity: {}; freq: {} +/- {}",
+                        pitch_i, idx, clarity, frequency, epsilon
+                    );
+
+                    let mut n_accepted = 0;
+                    let mut accepted = vec![false; remaining_freqs_in.len()];
+                    for (index, freq_in) in remaining_freqs_in.iter().enumerate() {
+                        // Not very stable, accept wrong octaves too...
+                        let (lower_freq, higher_freq) = match frequency < *freq_in {
+                            true => (frequency, *freq_in),
+                            false => (*freq_in, frequency),
+                        };
+
+                        let mut best_ratio = higher_freq / lower_freq;
+
+                        let mut scaled_lower_freq = lower_freq * 2.0;
+                        let mut curr_ratio = higher_freq / scaled_lower_freq;
+                        while (curr_ratio - 1.).abs() < (best_ratio - 1.).abs() {
+                            best_ratio = curr_ratio;
+                            scaled_lower_freq = scaled_lower_freq * 2.0;
+                            curr_ratio = higher_freq / scaled_lower_freq;
+                        }
+
+                        let ratio = higher_freq / lower_freq;
+
+                        if (best_ratio - 1.).abs() < 0.05 {
+                            println!("Freq: {}  Ratio: {}  Best: {}", freq_in, ratio, best_ratio);
+                            accepted[index] = true;
+                            n_accepted += 1;
+                        }
+                    }
+
+                    if n_accepted != 1 {
+                        failures += 1;
+                    }
+
+                    let mut index = 0;
+                    remaining_freqs_in.retain(|_| {
+                        let keep = !accepted[index];
+                        index += 1;
+                        keep
+                    });
+                }
+                None => {
+                    println!("Poly #{} - No peaks accepted.", pitch_i);
+                    failures += 1;
+                }
+            }
+        }
+    }
+
+    let frac_failures = (failures as f64) / (n_tests as f64);
+    println!(
+        "FAILURES: {} TOTAL: {}  FRAC: {}",
+        failures, n_tests, frac_failures
+    );
+
+    assert!(frac_failures < 0.2);
 }


### PR DESCRIPTION
Simple approach to attempt multi pitch detection:

The new `CombDetector` does the following:
- has an internal monophonic pitch detector (e.g. McLeod)
- detects the monophonic pitch of the signal using
- if a pitch is found, create a comb filter that removes the the pitch frequency and all of its octave from the original signal
- feed the new signal to the monophonic detector
- iterate...

Caveats:
- It doesn't work that well, McLeod and autocorrelation don't work well with signals that have multiple pitches
- Looks like a larger signal window is needed to have any type of result (4096?)