### PR TITLE
Code cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["algorithms", "multimedia::audio", "no-std"]
 readme = "README.md"
 
 [dependencies]
-rustfft = { version = "4.0.0", default-features = false }
+rustfft = { version = "5.0.1", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-complex = { version = "0.3", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,10 @@ readme = "README.md"
 rustfft = { version = "4.0.0", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-complex = { version = "0.3", default-features = false }
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "utils_benchmark"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ readme = "README.md"
 
 [dependencies]
 rustfft = { version = "5.0.1", default-features = false }
-num-traits = { version = "0.2", default-features = false }
-num-complex = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/benches/utils_benchmark.rs
+++ b/benches/utils_benchmark.rs
@@ -1,0 +1,19 @@
+use std::f64::consts::PI;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use pitch_detection::utils::peak::detect_peaks;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let v = (0..1024)
+        .into_iter()
+        .map(|v| ((v as f64) / PI / 30.).sin())
+        .collect::<Vec<f64>>();
+    let vv = v.as_slice();
+
+    c.bench_function("detect_peaks", |b| {
+        b.iter(|| detect_peaks(black_box(vv)).collect::<Vec<_>>())
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/utils_benchmark.rs
+++ b/benches/utils_benchmark.rs
@@ -1,9 +1,12 @@
 use std::f64::consts::PI;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use pitch_detection::utils::peak::detect_peaks;
+use pitch_detection::{
+    detector::{autocorrelation::AutocorrelationDetector, mcleod::McLeodDetector, PitchDetector},
+    utils::peak::detect_peaks,
+};
 
-pub fn criterion_benchmark(c: &mut Criterion) {
+pub fn utils_benchmark(c: &mut Criterion) {
     let v = (0..1024)
         .into_iter()
         .map(|v| ((v as f64) / PI / 30.).sin())
@@ -15,5 +18,49 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
+pub fn pitch_detect_benchmark(c: &mut Criterion) {
+    const SAMPLE_RATE: usize = 44100;
+    const SIZE: usize = 1024;
+    const PADDING: usize = SIZE / 2;
+    const POWER_THRESHOLD: f64 = 5.0;
+    const CLARITY_THRESHOLD: f64 = 0.7;
+
+    // Signal coming from some source (microphone, generated, etc...)
+    let dt = 1.0 / SAMPLE_RATE as f64;
+    let freq = 300.0;
+    let signal: Vec<f64> = (0..SIZE)
+        .map(|x| (2.0 * std::f64::consts::PI * x as f64 * dt * freq).sin())
+        .collect();
+
+    let mut mcleod_detector = McLeodDetector::new(SIZE, PADDING);
+    let mut autocorrelation_detector = AutocorrelationDetector::new(SIZE, PADDING);
+
+    c.bench_function("McLeod get_pitch", |b| {
+        b.iter(|| {
+            mcleod_detector
+                .get_pitch(
+                    black_box(&signal),
+                    SAMPLE_RATE,
+                    POWER_THRESHOLD,
+                    CLARITY_THRESHOLD,
+                )
+                .unwrap()
+        });
+    });
+
+    c.bench_function("Autocorrelation get_pitch", |b| {
+        b.iter(|| {
+            autocorrelation_detector
+                .get_pitch(
+                    black_box(&signal),
+                    SAMPLE_RATE,
+                    POWER_THRESHOLD,
+                    CLARITY_THRESHOLD,
+                )
+                .unwrap()
+        });
+    });
+}
+
+criterion_group!(benches, pitch_detect_benchmark, utils_benchmark);
 criterion_main!(benches);

--- a/src/detector/autocorrelation.rs
+++ b/src/detector/autocorrelation.rs
@@ -1,11 +1,10 @@
-use crate::detector::internals::autocorrelation;
-use crate::detector::internals::get_power_level;
 use crate::detector::internals::pitch_from_peaks;
 use crate::detector::internals::DetectorInternals;
 use crate::detector::internals::Pitch;
 use crate::detector::PitchDetector;
 use crate::float::Float;
 use crate::utils::peak::PeakCorrection;
+use crate::{detector::internals::autocorrelation, utils::buffer::square_sum};
 
 pub struct AutocorrelationDetector<T>
 where
@@ -41,7 +40,7 @@ where
             "McLeodDetector requires at least 1 real and 2 complex buffers"
         );
 
-        if get_power_level(signal) < power_threshold {
+        if square_sum(signal) < power_threshold {
             return None;
         }
 

--- a/src/detector/autocorrelation.rs
+++ b/src/detector/autocorrelation.rs
@@ -36,14 +36,21 @@ where
         clarity_threshold: T,
     ) -> Option<Pitch<T>> {
         assert_eq!(signal.len(), self.internals.size);
+        assert!(
+            self.internals.has_sufficient_buffers(1, 2),
+            "McLeodDetector requires at least 1 real and 2 complex buffers"
+        );
 
         if get_power_level(signal) < power_threshold {
             return None;
         }
 
-        let (signal_complex, rest) = self.internals.complex_buffers.split_first_mut().unwrap();
-        let (scratch, _) = rest.split_first_mut().unwrap();
-        let (autocorr, _) = self.internals.real_buffers.split_first_mut().unwrap();
+        let mut iter = self.internals.complex_buffers.iter_mut();
+        let signal_complex = iter.next().unwrap();
+        let scratch = iter.next().unwrap();
+
+        let mut iter = self.internals.real_buffers.iter_mut();
+        let autocorr = iter.next().unwrap();
 
         autocorrelation(signal, signal_complex, scratch, autocorr);
         let clarity_threshold = clarity_threshold * autocorr[0];

--- a/src/detector/internals.rs
+++ b/src/detector/internals.rs
@@ -1,4 +1,4 @@
-use num_complex::Complex;
+use rustfft::num_complex::Complex;
 use rustfft::FftPlanner;
 
 use crate::utils::buffer::copy_real_to_complex;

--- a/src/detector/internals.rs
+++ b/src/detector/internals.rs
@@ -40,18 +40,13 @@ where
         size: usize,
         padding: usize,
     ) -> Self {
-        let mut real_buffers: Vec<Vec<T>> = Vec::new();
-        let mut complex_buffers: Vec<Vec<Complex<T>>> = Vec::new();
+        let real_buffers: Vec<Vec<T>> = (0..n_real_buffers)
+            .map(|_| new_real_buffer(size + padding))
+            .collect();
 
-        for _i in 0..n_real_buffers {
-            let v = new_real_buffer(size + padding);
-            real_buffers.push(v);
-        }
-
-        for _i in 0..n_complex_buffers {
-            let v = new_complex_buffer(size + padding);
-            complex_buffers.push(v);
-        }
+        let complex_buffers: Vec<Vec<Complex<T>>> = (0..n_complex_buffers)
+            .map(|_| new_complex_buffer(size + padding))
+            .collect();
 
         DetectorInternals {
             size,
@@ -93,13 +88,14 @@ pub fn pitch_from_peaks<T>(
 where
     T: Float,
 {
+    let sample_rate = T::from_usize(sample_rate).unwrap();
     let peaks = detect_peaks(input);
+
     choose_peak(peaks, clarity_threshold)
         .map(|peak| correct_peak(peak, input, correction))
-        .map(|peak| {
-            let frequency = T::from_usize(sample_rate).unwrap() / peak.0;
-            let clarity = peak.1 / input[0];
-            Pitch { frequency, clarity }
+        .map(|peak| Pitch {
+            frequency: sample_rate / peak.0,
+            clarity: peak.1 / input[0],
         })
 }
 

--- a/src/detector/internals.rs
+++ b/src/detector/internals.rs
@@ -107,7 +107,7 @@ pub fn get_power_level<T>(signal: &[T]) -> T
 where
     T: Float + std::iter::Sum,
 {
-    signal.iter().map(|s| *s * *s).sum::<T>()
+    signal.iter().map(|&s| s * s).sum::<T>()
 }
 
 fn m_of_tau<T>(signal: &[T], signal_square_sum: Option<T>, result: &mut [T])
@@ -117,16 +117,18 @@ where
     assert!(result.len() >= signal.len());
 
     let signal_square_sum =
-        signal_square_sum.unwrap_or_else(|| signal.iter().map(|s| *s * *s).sum::<T>());
+        signal_square_sum.unwrap_or_else(|| signal.iter().map(|&s| s * s).sum::<T>());
 
-    result[0] = T::from_usize(2).unwrap() * signal_square_sum;
-    let last = result[1..].iter_mut().zip(signal).fold(
-        T::from_usize(2).unwrap() * signal_square_sum,
-        |old, (r, s)| {
-            *r = old - *s * *s;
+    let start = T::from_usize(2).unwrap() * signal_square_sum;
+    result[0] = start;
+    let last = result[1..]
+        .iter_mut()
+        .zip(signal)
+        .fold(start, |old, (r, &s)| {
+            *r = old - s * s;
             *r
-        },
-    );
+        });
+    // Pad the end of `result` with the last value
     result[signal.len()..].iter_mut().for_each(|r| *r = last);
 }
 

--- a/src/detector/internals.rs
+++ b/src/detector/internals.rs
@@ -1,5 +1,5 @@
 use num_complex::Complex;
-use rustfft::FFTplanner;
+use rustfft::FftPlanner;
 
 use crate::utils::buffer::copy_real_to_complex;
 use crate::utils::buffer::new_complex_buffer;
@@ -75,16 +75,15 @@ pub fn autocorrelation<T>(
 ) where
     T: Float,
 {
-    let mut planner = FFTplanner::new(false);
-    let fft = planner.plan_fft(signal_complex.len());
-    let mut planner = FFTplanner::new(true);
-    let inv_fft = planner.plan_fft(signal_complex.len());
+    let mut planner = FftPlanner::new();
+    let fft = planner.plan_fft_forward(signal_complex.len());
+    let inv_fft = planner.plan_fft_inverse(signal_complex.len());
 
     // Compute the autocorrelation
     copy_real_to_complex(signal, signal_complex, ComplexComponent::Re);
-    fft.process(signal_complex, scratch);
-    modulus_squared(scratch);
-    inv_fft.process(scratch, signal_complex);
+    fft.process_with_scratch(signal_complex, scratch);
+    modulus_squared(signal_complex);
+    inv_fft.process_with_scratch(signal_complex, scratch);
     copy_complex_to_real(signal_complex, result, ComplexComponent::Re);
 }
 

--- a/src/detector/internals.rs
+++ b/src/detector/internals.rs
@@ -55,6 +55,11 @@ where
             complex_buffers,
         }
     }
+
+    // Check whether there are at least the appropriate number of real and complex buffers.
+    pub fn has_sufficient_buffers(&self, n_real_buffers: usize, n_complex_buffers: usize) -> bool {
+        self.real_buffers.len() >= n_real_buffers && self.complex_buffers.len() >= n_complex_buffers
+    }
 }
 
 pub fn autocorrelation<T>(

--- a/src/detector/mcleod.rs
+++ b/src/detector/mcleod.rs
@@ -1,10 +1,10 @@
-use crate::detector::internals::get_power_level;
 use crate::detector::internals::normalized_square_difference;
 use crate::detector::internals::pitch_from_peaks;
 use crate::detector::internals::DetectorInternals;
 use crate::detector::internals::Pitch;
 use crate::detector::PitchDetector;
 use crate::float::Float;
+use crate::utils::buffer::square_sum;
 use crate::utils::peak::PeakCorrection;
 
 pub struct McLeodDetector<T>
@@ -41,7 +41,7 @@ where
             "McLeodDetector requires at least 2 real and 2 complex buffers"
         );
 
-        if get_power_level(signal) < power_threshold {
+        if square_sum(signal) < power_threshold {
             return None;
         }
 

--- a/src/detector/mcleod.rs
+++ b/src/detector/mcleod.rs
@@ -61,7 +61,7 @@ where
 }
 
 /// Split the first two elements from `array` off as mutable elements in a tuple.
-fn split_first_two_mut<T>(mut array: &mut Vec<T>) -> (&mut T, &mut T) {
+fn split_first_two_mut<T>(array: &mut Vec<T>) -> (&mut T, &mut T) {
     let mut iter = array.iter_mut();
     (iter.next().unwrap(), iter.next().unwrap())
 }

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -1,4 +1,4 @@
-use num_traits::float::FloatCore as NumFloatCore;
+use rustfft::num_traits::float::FloatCore as NumFloatCore;
 use rustfft::FftNum;
 use std::fmt::{Debug, Display};
 

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -1,7 +1,8 @@
 use num_traits::float::FloatCore as NumFloatCore;
 use rustfft::FFTnum;
+use std::fmt::Display;
 
-pub trait Float: NumFloatCore + FFTnum {}
+pub trait Float: Display + NumFloatCore + FFTnum {}
 
 impl Float for f64 {}
 impl Float for f32 {}

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -1,8 +1,8 @@
 use num_traits::float::FloatCore as NumFloatCore;
 use rustfft::FFTnum;
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 
-pub trait Float: Display + NumFloatCore + FFTnum {}
+pub trait Float: Display + Debug + NumFloatCore + FFTnum {}
 
 impl Float for f64 {}
 impl Float for f32 {}

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -1,8 +1,8 @@
 use num_traits::float::FloatCore as NumFloatCore;
-use rustfft::FFTnum;
+use rustfft::FftNum;
 use std::fmt::{Debug, Display};
 
-pub trait Float: Display + Debug + NumFloatCore + FFTnum {}
+pub trait Float: Display + Debug + NumFloatCore + FftNum {}
 
 impl Float for f64 {}
 impl Float for f32 {}

--- a/src/utils/buffer.rs
+++ b/src/utils/buffer.rs
@@ -1,5 +1,5 @@
-use num_complex::Complex;
-use num_traits::Zero;
+use rustfft::num_complex::Complex;
+use rustfft::num_traits::Zero;
 
 use crate::float::Float;
 

--- a/src/utils/buffer.rs
+++ b/src/utils/buffer.rs
@@ -60,3 +60,20 @@ pub fn copy_complex_to_real<T: Float>(
         .iter_mut()
         .for_each(|o| *o = T::zero());
 }
+
+/// Computes |x|^2 for each complex value x in `arr`. This function
+/// modifies `arr` in place and leaves the complex component zero.
+pub fn modulus_squared<'a, T: Float>(arr: &'a mut [Complex<T>]) {
+    for mut s in arr {
+        s.re = s.re * s.re + s.im * s.im;
+        s.im = T::zero();
+    }
+}
+
+/// Compute the sum of the square of each element of `arr`.
+pub fn square_sum<T>(arr: &[T]) -> T
+where
+    T: Float + std::iter::Sum,
+{
+    arr.iter().map(|&s| s * s).sum::<T>()
+}

--- a/src/utils/peak.rs
+++ b/src/utils/peak.rs
@@ -121,7 +121,7 @@ mod tests {
         assert_eq!(x, 0.75);
         assert_eq!(y, -1.375);
 
-        // Test off concave-up parabolas
+        // Test of concave-up parabolas
         fn quad3(x: f64) -> f64 {
             x * x + 2.0
         }

--- a/src/utils/peak.rs
+++ b/src/utils/peak.rs
@@ -5,11 +5,6 @@ pub enum PeakCorrection {
     None,
 }
 
-struct Point<T: Float> {
-    x: T,
-    y: T,
-}
-
 fn detect_crossings<'a, T: Float>(arr: &'a [T]) -> impl Iterator<Item = (usize, usize)> + 'a {
     arr.windows(2)
         .enumerate()
@@ -61,36 +56,45 @@ pub fn correct_peak<T: Float>(peak: (usize, T), data: &[T], correction: PeakCorr
     match correction {
         PeakCorrection::Quadratic => {
             let idx = peak.0;
-            let point = quadratic_interpolation(
-                Point {
-                    x: T::from_usize(idx - 1).unwrap(),
-                    y: data[idx - 1],
-                },
-                Point {
-                    x: T::from_usize(idx).unwrap(),
-                    y: data[idx],
-                },
-                Point {
-                    x: T::from_usize(idx + 1).unwrap(),
-                    y: data[idx + 1],
-                },
-            );
-            (point.x, point.y)
+            let (x, y) = find_quadratic_peak(data[idx - 1], data[idx], data[idx + 1]);
+            (x + T::from_usize(idx).unwrap(), y)
         }
         PeakCorrection::None => (T::from_usize(peak.0).unwrap(), peak.1),
     }
 }
 
-fn quadratic_interpolation<T: Float>(
-    left: Point<T>,
-    center: Point<T>,
-    right: Point<T>,
-) -> Point<T> {
-    let shift = T::from_f64(0.5).unwrap() * (right.y - left.y)
-        / (T::from_f64(2.0).unwrap() * center.y - left.y - right.y);
-    let x = center.x + shift;
-    let y = center.y + T::from_f64(0.25).unwrap() * (right.y - left.y) * shift;
-    Point { x, y }
+/// Use a quadratic interpolation to find the maximum of
+/// a parabola passing through `(-1, y0)`, `(0, y1)`, `(1, y2)`.
+///
+/// The output is of the form `(x-offset, peak value)`.
+fn find_quadratic_peak<T: Float>(y0: T, y1: T, y2: T) -> (T, T) {
+    // The quadratic ax^2+bx+c passing through
+    // (-1, y0), (0, y1), (1, y2), the
+    // has coefficients
+    //
+    // a = y0/2 - y1 + y2/2
+    // b = (y2 - y0)/2
+    // c = y1
+    //
+    // and a maximum at x=-b/(2a) and y=-b^2/(4a) + c
+
+    // Some constants
+    let two = T::from_f64(2.).unwrap();
+    let four = T::from_f64(4.).unwrap();
+
+    let a = (y0 + y2) / two - y1;
+    let b = (y2 - y0) / two;
+    let c = y1;
+
+    // If we're concave up, the maximum is at one of the end points
+    if a > T::zero() {
+        if y0 > y2 {
+            return (-T::one(), y0);
+        }
+        return (T::one(), y2);
+    }
+
+    (-b / (two * a), -b * b / (four * a) + c)
 }
 
 #[cfg(test)]
@@ -99,21 +103,34 @@ mod tests {
 
     #[test]
     fn peak_correction() {
-        let point = quadratic_interpolation(
-            Point {
-                x: -1.5,
-                y: -(1.5 * 1.5) + 4.0,
-            },
-            Point {
-                x: -0.5,
-                y: -(0.5 * 0.5) + 4.0,
-            },
-            Point {
-                x: 0.5,
-                y: -(0.5 * 0.5) + 4.0,
-            },
-        );
-        assert_eq!(point.x, 0.0);
-        assert_eq!(point.y, 4.0);
+        fn quad1(x: f64) -> f64 {
+            -x * x + 4.0
+        }
+        let (x, y) = find_quadratic_peak(quad1(-1.5), quad1(-0.5), quad1(0.5));
+        assert_eq!(x - 0.5, 0.0);
+        assert_eq!(y, 4.0);
+        let (x, y) = find_quadratic_peak(quad1(-3.5), quad1(-2.5), quad1(-1.5));
+        assert_eq!(x - 2.5, 0.0);
+        assert_eq!(y, 4.0);
+
+        fn quad2(x: f64) -> f64 {
+            -2. * x * x + 3. * x - 2.5
+        }
+
+        let (x, y) = find_quadratic_peak(quad2(-1.), quad2(0.), quad2(1.));
+        assert_eq!(x, 0.75);
+        assert_eq!(y, -1.375);
+
+        // Test off concave-up parabolas
+        fn quad3(x: f64) -> f64 {
+            x * x + 2.0
+        }
+
+        let (x, y) = find_quadratic_peak(quad3(0.), quad3(1.), quad3(2.));
+        assert_eq!(x + 1., 2.);
+        assert_eq!(y, 6.);
+        let (x, y) = find_quadratic_peak(quad3(-2.), quad3(-1.), quad3(0.));
+        assert_eq!(x - 1., -2.);
+        assert_eq!(y, 6.);
     }
 }


### PR DESCRIPTION
I've done some minor code cleanups.

Looking around in the code, it's really unpleasant to do `Float::from_f64(...).unwrap()` everywhere. Is there a way to make the `Float` trait automatically know how to multiply and add with `f64`/`f32` types?