### PR TITLE
Enable multithreaded consumers by changing Rc<RefCell<_>> to Arc<RwLock<_>>

### DIFF
--- a/src/detector/autocorrelation.rs
+++ b/src/detector/autocorrelation.rs
@@ -57,7 +57,7 @@ where
         }
 
         let result_ref = self.internals.buffers.get_real_buffer();
-        let result = &mut result_ref.borrow_mut()[..];
+        let result = &mut result_ref.write().unwrap()[..];
 
         autocorrelation(signal, &mut self.internals.buffers, result);
         let clarity_threshold = clarity_threshold * result[0];

--- a/src/detector/internals.rs
+++ b/src/detector/internals.rs
@@ -53,8 +53,8 @@ where
     T: Float,
 {
     let (ref1, ref2) = (buffers.get_complex_buffer(), buffers.get_complex_buffer());
-    let signal_complex = &mut ref1.borrow_mut()[..];
-    let scratch = &mut ref2.borrow_mut()[..];
+    let signal_complex = &mut ref1.write().unwrap()[..];
+    let scratch = &mut ref2.write().unwrap()[..];
 
     let mut planner = FftPlanner::new();
     let fft = planner.plan_fft_forward(signal_complex.len());
@@ -116,7 +116,7 @@ where
     let two = T::from_usize(2).unwrap();
 
     let scratch_ref = buffers.get_real_buffer();
-    let scratch = &mut scratch_ref.borrow_mut()[..];
+    let scratch = &mut scratch_ref.write().unwrap()[..];
 
     autocorrelation(signal, buffers, result);
     m_of_tau(signal, Some(result[0]), scratch);
@@ -156,9 +156,9 @@ pub fn windowed_autocorrelation<T>(
         buffers.get_complex_buffer(),
     );
 
-    let signal_complex = &mut scratch_ref1.borrow_mut()[..signal.len()];
-    let truncated_signal_complex = &mut scratch_ref2.borrow_mut()[..signal.len()];
-    let scratch = &mut scratch_ref3.borrow_mut()[..signal.len()];
+    let signal_complex = &mut scratch_ref1.write().unwrap()[..signal.len()];
+    let truncated_signal_complex = &mut scratch_ref2.write().unwrap()[..signal.len()];
+    let scratch = &mut scratch_ref3.write().unwrap()[..signal.len()];
 
     // To achieve the windowed autocorrelation, we compute the cross correlation between
     // the original signal and the signal truncated to lie in `0..window_size`

--- a/src/detector/mcleod.rs
+++ b/src/detector/mcleod.rs
@@ -62,7 +62,7 @@ where
             return None;
         }
         let result_ref = self.internals.buffers.get_real_buffer();
-        let result = &mut result_ref.borrow_mut()[..];
+        let result = &mut result_ref.write().unwrap()[..];
 
         normalized_square_difference(signal, &mut self.internals.buffers, result);
         pitch_from_peaks(

--- a/src/detector/yin.rs
+++ b/src/detector/yin.rs
@@ -72,7 +72,7 @@ where
         }
 
         let result_ref = self.internals.buffers.get_real_buffer();
-        let result = &mut result_ref.borrow_mut()[..window_size];
+        let result = &mut result_ref.write().unwrap()[..window_size];
 
         // STEP 2: Calculate the difference function, d_t.
         windowed_square_error(signal, window_size, &mut self.internals.buffers, result);

--- a/src/utils/buffer.rs
+++ b/src/utils/buffer.rs
@@ -1,6 +1,6 @@
 use rustfft::num_complex::Complex;
 use rustfft::num_traits::Zero;
-use std::{cell::RefCell, rc::Rc};
+use std::{sync::{RwLock, Arc}};
 
 use crate::float::Float;
 
@@ -91,31 +91,31 @@ where
 ///  let buf_cell1 = buffers.get_real_buffer();
 ///  {
 ///      // This buffer won't be dropped until the end of the function
-///      let mut buf1 = buf_cell1.borrow_mut();
+///      let mut buf1 = buf_cell1.write().unwrap();
 ///      buf1[0] = 5.5;
 ///  }
 ///  {
 ///      // This buffer will be dropped when the scope ends
 ///      let buf_cell2 = buffers.get_real_buffer();
-///      let mut buf2 = buf_cell2.borrow_mut();
+///      let mut buf2 = buf_cell2.write().unwrap();
 ///      buf2[1] = 6.6;
 ///  }
 ///  {
 ///      // This buffer will be dropped when the scope ends
 ///      // It is the same buffer that was just used (i.e., it's a reused buffer)
 ///      let buf_cell3 = buffers.get_real_buffer();
-///      let mut buf3 = buf_cell3.borrow_mut();
+///      let mut buf3 = buf_cell3.write().unwrap();
 ///      buf3[2] = 7.7;
 ///  }
 ///  // The first buffer we asked for should not have been reused.
-///  assert_eq!(&buf_cell1.borrow()[..], &[5.5, 0., 0.]);
+///  assert_eq!(&buf_cell1.read().unwrap()[..], &[5.5, 0., 0.]);
 ///  let buf_cell2 = buffers.get_real_buffer();
 ///  // The second buffer was reused because it was dropped and then another buffer was requested.
-///  assert_eq!(&buf_cell2.borrow()[..], &[0.0, 6.6, 7.7]);
+///  assert_eq!(&buf_cell2.read().unwrap()[..], &[0.0, 6.6, 7.7]);
 /// ```
 pub struct BufferPool<T> {
-    real_buffers: Vec<Rc<RefCell<Vec<T>>>>,
-    complex_buffers: Vec<Rc<RefCell<Vec<Complex<T>>>>>,
+    real_buffers: Vec<Arc<RwLock<Vec<T>>>>,
+    complex_buffers: Vec<Arc<RwLock<Vec<Complex<T>>>>>,
     pub buffer_size: usize,
 }
 
@@ -127,39 +127,39 @@ impl<T: Float> BufferPool<T> {
             buffer_size,
         }
     }
-    fn add_real_buffer(&mut self) -> Rc<RefCell<Vec<T>>> {
+    fn add_real_buffer(&mut self) -> Arc<RwLock<Vec<T>>> {
         self.real_buffers
-            .push(Rc::new(RefCell::new(new_real_buffer::<T>(
+            .push(Arc::new(RwLock::new(new_real_buffer::<T>(
                 self.buffer_size,
             ))));
-        Rc::clone(&self.real_buffers.last().unwrap())
+        Arc::clone(&self.real_buffers.last().unwrap())
     }
-    fn add_complex_buffer(&mut self) -> Rc<RefCell<Vec<Complex<T>>>> {
+    fn add_complex_buffer(&mut self) -> Arc<RwLock<Vec<Complex<T>>>> {
         self.complex_buffers
-            .push(Rc::new(RefCell::new(new_complex_buffer::<T>(
+            .push(Arc::new(RwLock::new(new_complex_buffer::<T>(
                 self.buffer_size,
             ))));
-        Rc::clone(&self.complex_buffers.last().unwrap())
+        Arc::clone(&self.complex_buffers.last().unwrap())
     }
-    /// Get a reference to a buffer that can e used until it is `Drop`ed. Call
-    /// `.borrow_mut()` to get a reference to a mutable version of the buffer.
-    pub fn get_real_buffer(&mut self) -> Rc<RefCell<Vec<T>>> {
+    /// Get a reference to a buffer that can be used until it is `Drop`ed. Call
+    /// `.write()` to get a reference to a mutable version of the buffer.
+    pub fn get_real_buffer(&mut self) -> Arc<RwLock<Vec<T>>> {
         self.real_buffers
             .iter()
-            // If the Rc count is 1, we haven't loaned the buffer out yet.
-            .find(|&buf| Rc::strong_count(buf) == 1)
-            .map(|buf| Rc::clone(buf))
+            // If the Arc count is 1, we haven't loaned the buffer out yet.
+            .find(|&buf| Arc::strong_count(buf) == 1)
+            .map(|buf| Arc::clone(buf))
             // If we haven't found a buffer we can reuse, create one.
             .unwrap_or_else(|| self.add_real_buffer())
     }
-    /// Get a reference to a buffer that can e used until it is `Drop`ed. Call
-    /// `.borrow_mut()` to get a reference to a mutable version of the buffer.
-    pub fn get_complex_buffer(&mut self) -> Rc<RefCell<Vec<Complex<T>>>> {
+    /// Get a reference to a buffer that can be used until it is `Drop`ed. Call
+    /// `.write()` to get a reference to a mutable version of the buffer.
+    pub fn get_complex_buffer(&mut self) -> Arc<RwLock<Vec<Complex<T>>>> {
         self.complex_buffers
             .iter()
-            // If the Rc count is 1, we haven't loaned the buffer out yet.
-            .find(|&buf| Rc::strong_count(buf) == 1)
-            .map(|buf| Rc::clone(buf))
+            // If the Arc count is 1, we haven't loaned the buffer out yet.
+            .find(|&buf| Arc::strong_count(buf) == 1)
+            .map(|buf| Arc::clone(buf))
             // If we haven't found a buffer we can reuse, create one.
             .unwrap_or_else(|| self.add_complex_buffer())
     }
@@ -171,23 +171,23 @@ fn test_buffers() {
     let buf_cell1 = buffers.get_real_buffer();
     {
         // This buffer won't be dropped until the end of the function
-        let mut buf1 = buf_cell1.borrow_mut();
+        let mut buf1 = buf_cell1.write().unwrap();
         buf1[0] = 5.5;
     }
     {
         // This buffer will be dropped when the scope ends
         let buf_cell2 = buffers.get_real_buffer();
-        let mut buf2 = buf_cell2.borrow_mut();
+        let mut buf2 = buf_cell2.write().unwrap();
         buf2[1] = 6.6;
     }
     {
         // This buffer will be dropped when the scope ends
         // It is the same buffer that was just used (i.e., it's a reused buffer)
         let buf_cell3 = buffers.get_real_buffer();
-        let mut buf3 = buf_cell3.borrow_mut();
+        let mut buf3 = buf_cell3.write().unwrap();
         buf3[2] = 7.7;
     }
     // We're peering into the internals of `BufferPool`. This shouldn't normally be done.
-    assert_eq!(&buffers.real_buffers[0].borrow()[..], &[5.5, 0., 0.]);
-    assert_eq!(&buffers.real_buffers[1].borrow()[..], &[0.0, 6.6, 7.7]);
+    assert_eq!(&buffers.real_buffers[0].read().unwrap()[..], &[5.5, 0., 0.]);
+    assert_eq!(&buffers.real_buffers[1].read().unwrap()[..], &[0.0, 6.6, 7.7]);
 }


### PR DESCRIPTION
First off, this library is great! 

I wanted to propose a change that would allow `pitch-detection` to integrate with my current audio projects.

Consider the following example:
```rust
use std::sync::{Arc, RwLock};

use cpal::{traits::{HostTrait, DeviceTrait, StreamTrait}, Data};
use pitch_detection::detector::{mcleod::McLeodDetector, PitchDetector};

pub fn main() {
    let host = cpal::default_host();
    let device = host.default_input_device().unwrap();

    println!("Input device: {:?}", device.name());

    const SAMPLE_RATE: usize = 44100;
    const SIZE: usize = 512;
    const PADDING: usize = SIZE / 2;
    const POWER_THRESHOLD: f32 = 5.0;
    const CLARITY_THRESHOLD: f32 = 0.7;

    let detector = McLeodDetector::<f32>::new(SIZE, PADDING);
    let detector = Arc::new(RwLock::new(detector));
    let audio_detector = detector.clone();

    let config = device
        .default_input_config()
        .expect("Failed to get default input config");
    println!("Default input config: {:?}", config);

    let err_fn = |err| eprintln!("an error occurred on stream: {}", err);
    let data_fn = move |data: &Data, _info: &cpal::InputCallbackInfo| {
        let audio_detector = &mut *audio_detector.write().unwrap();
        let pitch = audio_detector
            .get_pitch(data.as_slice().unwrap(), SAMPLE_RATE, POWER_THRESHOLD, CLARITY_THRESHOLD);
        if let Some(pitch) = pitch {
            println!("{:?}", pitch.frequency);
        }
    };

    let stream = device
        .build_input_stream_raw(
            &config.into(),
            cpal::SampleFormat::F32,
            data_fn,
            err_fn,
        )
        .unwrap();

    stream.play().unwrap();

    loop {
        std::thread::sleep(std::time::Duration::from_secs(10));
    }
}
```

Using `pitch-detection` v0.3.0, we're unable to access the detector from our audio callback closure:
> `Rc<RefCell<Vec<f32>>>` cannot be sent between threads safely

With this patch, the locking and refcount intrinsics are replaced with thread-safe equivalents, allowing our CPAL example to compile! 

I've tested it on my local machine and it works correctly. All tests pass as well, and I've made sure to update the docstrings where appropriate. Let me know if you have any feedback.