### PR TITLE
Consider switching to `easyfft`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["algorithms", "multimedia::audio", "no-std"]
 readme = "README.md"
 
 [dependencies]
+num-traits = "0.2.15"
 rustfft = { version = "6.0.1", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 num-traits = "0.2.15"
-rustfft = { version = "6.0.1", default-features = false }
+easyfft = "0.3.3"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/detector/autocorrelation.rs
+++ b/src/detector/autocorrelation.rs
@@ -41,7 +41,7 @@ where
 
 impl<T> PitchDetector<T> for AutocorrelationDetector<T>
 where
-    T: Float + std::iter::Sum,
+    T: Float + std::iter::Sum + Default,
 {
     fn get_pitch(
         &mut self,

--- a/src/detector/mcleod.rs
+++ b/src/detector/mcleod.rs
@@ -47,7 +47,7 @@ where
 
 impl<T> PitchDetector<T> for McLeodDetector<T>
 where
-    T: Float + std::iter::Sum,
+    T: Float + std::iter::Sum + Default,
 {
     fn get_pitch(
         &mut self,

--- a/src/detector/yin.rs
+++ b/src/detector/yin.rs
@@ -51,7 +51,7 @@ where
 /// Pitch detection based on the YIN algorithm. See <http://recherche.ircam.fr/equipes/pcm/cheveign/ps/2002_JASA_YIN_proof.pdf>
 impl<T> PitchDetector<T> for YINDetector<T>
 where
-    T: Float + std::iter::Sum,
+    T: Float + std::iter::Sum + Default,
 {
     fn get_pitch(
         &mut self,

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -1,6 +1,6 @@
 //! Generic [Float] type which acts as a stand-in for `f32` or `f64`.
+use easyfft::FftNum;
 use num_traits::float::FloatCore as NumFloatCore;
-use rustfft::FftNum;
 use std::fmt::{Debug, Display};
 
 /// Signals are processed as arrays of [Float]s. A [Float] is normally `f32` or `f64`.

--- a/src/float/mod.rs
+++ b/src/float/mod.rs
@@ -1,5 +1,5 @@
 //! Generic [Float] type which acts as a stand-in for `f32` or `f64`.
-use rustfft::num_traits::float::FloatCore as NumFloatCore;
+use num_traits::float::FloatCore as NumFloatCore;
 use rustfft::FftNum;
 use std::fmt::{Debug, Display};
 

--- a/src/utils/buffer.rs
+++ b/src/utils/buffer.rs
@@ -1,5 +1,5 @@
+use num_traits::Zero;
 use rustfft::num_complex::Complex;
-use rustfft::num_traits::Zero;
 use std::{cell::RefCell, rc::Rc};
 
 use crate::float::Float;

--- a/src/utils/buffer.rs
+++ b/src/utils/buffer.rs
@@ -1,5 +1,5 @@
+use easyfft::num_complex::Complex;
 use num_traits::Zero;
-use rustfft::num_complex::Complex;
 use std::{cell::RefCell, rc::Rc};
 
 use crate::float::Float;


### PR DESCRIPTION
This makes the logic simpler and manages the planner and scratch buffers behind the scenes resulting in a ~80% benchmark improvement across the board:
```
McLeod get_pitch        time:   [11.114 µs 11.118 µs 11.121 µs]
                        change: [-81.978% -81.964% -81.951%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low severe
  1 (1.00%) high mild

Autocorrelation get_pitch
                        time:   [7.9310 µs 7.9348 µs 7.9388 µs]
                        change: [-86.719% -86.711% -86.703%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild

YIN get_pitch           time:   [8.8091 µs 8.8150 µs 8.8222 µs]
                        change: [-78.127% -78.106% -78.085%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe

detect_peaks            time:   [523.75 ns 524.12 ns 524.48 ns]
                        change: [+0.0519% +0.3183% +0.5176%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
```

Unfortunately it requires an extra trait bound on `Default` for the fft elements. This is not neccesary but requires changes to `rustfft` tracked in https://github.com/ejmahler/RustFFT/issues/105.